### PR TITLE
fix: 🔧 fix country typo

### DIFF
--- a/data.json
+++ b/data.json
@@ -845,7 +845,7 @@
   },
   {
     "value": "SR",
-    "label": "Surilabel"
+    "label": "Suriname"
   },
   {
     "value": "SJ",


### PR DESCRIPTION
`"Surilabel"` => `"Suriname"`