### PR TITLE
Simplify the Taiwan name

### DIFF
--- a/data.json
+++ b/data.json
@@ -869,7 +869,7 @@
   },
   {
     "value": "TW",
-    "label": "Taiwan, Province of China"
+    "label": "Taiwan"
   },
   {
     "value": "TJ",


### PR DESCRIPTION
Though Taiwan is not internationally recognized as a country, is it certainly not a Chinese province. Taiwan, officially the Republic of China (ROC) has its own Constitution, government and currency. The Taiwanese people are not obligated to report its affairs to the Chinese capital of Beijing; and do not need to obey by mainland Chinese political policies. If you have seen the the Taiwanese leader featured on the media, including CNN and BBC, they refer to her as the “Taiwanese President” and not the “Taiwanese Provincial Governor.”
There is no denial Taiwan’s independence in controversial, yet “province” is certainly not the term to classify this island.